### PR TITLE
Update Convert.php

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -10,7 +10,7 @@ class Convert
     }
 
     public static function rgbChannelToHexChannel(int $rgbValue): string
-    {
-        return dechex($rgbValue);
+    {       
+        return str_pad(dechex($rgbValue), 2, '0', STR_PAD_LEFT);
     }
 }


### PR DESCRIPTION
Pad RGB channel with 0 in order to avoid message :
"Hex values must contain exactly 2 characters, `A` contains 1 characters. "
when RGB object is converted to Hex object.