### PR TITLE
Allow spaces in rgb(a) colors

### DIFF
--- a/src/Rgb.php
+++ b/src/Rgb.php
@@ -23,9 +23,10 @@ class Rgb
         Validate::rgbColorString($string);
 
         $matches = null;
-        preg_match('/rgb\((\d{1,3},\d{1,3},\d{1,3})\)/i', $string, $matches);
+        preg_match('/rgb\( *(\d{1,3} *, *\d{1,3} *, *\d{1,3}) *\)/i', $string, $matches);
 
-        list($red, $green, $blue) = explode(',', $matches[1]);
+        $channels = explode(',', $matches[1]);
+        list($red, $green, $blue) = array_map('trim', $channels);
 
         return new static($red, $green, $blue);
     }

--- a/src/Rgba.php
+++ b/src/Rgba.php
@@ -28,9 +28,10 @@ class Rgba
         Validate::rgbaColorString($string);
 
         $matches = null;
-        preg_match('/rgba\((\d{1,3},\d{1,3},\d{1,3},[0-1](\.\d{1,2})?)\)/i', $string, $matches);
+        preg_match('/rgba\( *(\d{1,3} *, *\d{1,3} *, *\d{1,3} *, *[0-1](\.\d{1,2})?) *\)/i', $string, $matches);
 
-        list($red, $green, $blue, $alpha) = explode(',', $matches[1]);
+        $channels = explode(',', $matches[1]);
+        list($red, $green, $blue, $alpha) = array_map('trim', $channels);
 
         return new static($red, $green, $blue, $alpha);
     }

--- a/src/Validate.php
+++ b/src/Validate.php
@@ -33,14 +33,14 @@ class Validate
 
     public static function rgbColorString($string)
     {
-        if (! preg_match('/rgb\(\d{1,3},\d{1,3},\d{1,3}\)/i', $string)) {
+        if (! preg_match('/rgb\( *\d{1,3} *, *\d{1,3} *, *\d{1,3} *\)/i', $string)) {
             throw InvalidColorValue::malformedRgbColorString($string);
         }
     }
 
     public static function rgbaColorString($string)
     {
-        if (! preg_match('/rgba\(\d{1,3},\d{1,3},\d{1,3},[0-1](\.\d{1,2})?\)/i', $string)) {
+        if (! preg_match('/rgba\( *\d{1,3} *, *\d{1,3} *, *\d{1,3} *, *[0-1](\.\d{1,2})? *\)/i', $string)) {
             throw InvalidColorValue::malformedRgbaColorString($string);
         }
     }

--- a/tests/RgbTest.php
+++ b/tests/RgbTest.php
@@ -46,6 +46,17 @@ class RgbTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_be_created_from_a_string_with_spaces()
+    {
+        $rgb = Rgb::fromString('  rgb(  55  ,  155  ,  255  )  ');
+
+        $this->assertInstanceOf(Rgb::class, $rgb);
+        $this->assertEquals(55, $rgb->red());
+        $this->assertEquals(155, $rgb->green());
+        $this->assertEquals(255, $rgb->blue());
+    }
+
+    /** @test */
     public function it_cant_be_created_from_malformed_string()
     {
         $this->expectException(InvalidColorValue::class);

--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -64,6 +64,18 @@ class RgbaTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_be_created_from_a_string_with_spaces()
+    {
+        $rgba = Rgba::fromString('  rgba(  55  ,  155  ,  255  ,  0.5  )  ');
+
+        $this->assertInstanceOf(Rgba::class, $rgba);
+        $this->assertEquals(55, $rgba->red());
+        $this->assertEquals(155, $rgba->green());
+        $this->assertEquals(255, $rgba->blue());
+        $this->assertEquals(0.5, $rgba->alpha());
+    }
+
+    /** @test */
     public function it_cant_be_created_from_malformed_string()
     {
         $this->expectException(InvalidColorValue::class);


### PR DESCRIPTION
This allows to instanciate a rgb(a) color even if it contains spaces, just like in a browser:

```php
Rgb::fromString('  rgb( 1 , 2 , 3 ) ');
Rgba::fromString('  rgba( 1 , 2 , 3 , 1 ) ');
```