### PR TITLE
Add a color factory

### DIFF
--- a/src/Exceptions/InvalidColorValue.php
+++ b/src/Exceptions/InvalidColorValue.php
@@ -42,4 +42,9 @@ class InvalidColorValue extends Exception
     {
         return new static("Rgba color string `{$string}` is malformed. An rgba color contains 3 comma separated values between 0 and 255 with an alpha value between 0 and 1, wrapped in `rgba()`, e.g. `rgb(0,0,255,0.5)`.");
     }
+
+    public static function malformedColorString(string $string): self
+    {
+        return new static("Color string `{$string}` doesn't match any of the available colors.");
+    }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Spatie\Color;
+
+use ReflectionClass;
+use Spatie\Color\Exceptions\InvalidColorValue;
+
+class Factory
+{
+    const EXCLUDED_FILES = ['.', '..'];
+
+    public static function fromString(string $string): Color
+    {
+        $colorClasses = self::getColorClasses();
+
+        foreach ($colorClasses as $colorClass) {
+            try {
+                return call_user_func("$colorClass::fromString", $string);
+            } catch (InvalidColorValue $e) {
+                // Catch the exception but never throw it.
+            }
+        }
+
+        throw InvalidColorValue::malformedColorString($string);
+    }
+
+    protected static function getColorClasses(): array
+    {
+        return [
+            Hex::class,
+            Rgb::class,
+            Rgba::class,
+        ];
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Spatie\Color\Test;
+
+use Spatie\Color\Hex;
+use Spatie\Color\Rgb;
+use Spatie\Color\Rgba;
+use Spatie\Color\Factory;
+use Spatie\Color\Exceptions\InvalidColorValue;
+
+class FactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /** @test */
+    public function it_can_create_a_hex_color_from_a_string()
+    {
+        $hex = Factory::fromString('#aabbcc');
+
+        $this->assertInstanceOf(Hex::class, $hex);
+    }
+
+    /** @test */
+    public function it_can_create_a_rgb_color_from_a_string()
+    {
+        $rgb = Factory::fromString('rgb(55,155,255)');
+
+        $this->assertInstanceOf(Rgb::class, $rgb);
+    }
+
+    /** @test */
+    public function it_can_create_a_rgba_color_from_a_string()
+    {
+        $rgba = Factory::fromString('rgba(55,155,255,0.5)');
+
+        $this->assertInstanceOf(Rgba::class, $rgba);
+    }
+
+    /** @test */
+    public function it_cant_create_a_color_from_malformed_string()
+    {
+        $this->expectException(InvalidColorValue::class);
+
+        Factory::fromString('abcd');
+    }
+}


### PR DESCRIPTION
**This pull request requires #11 to be approved**

This factory allows to create a color from a string without knowing the type:

```php
Spatie\Color\Factory::fromString('#aabbcc'); // Returns a Spatie\Color\Hex instance
Spatie\Color\Factory::fromString('rgb(1,2,3)'); // Returns a Spatie\Color\Rgb instance
Spatie\Color\Factory::fromString('rgba(1,2,3,0.5)'); // Returns a Spatie\Color\Rgba instance
```