### PR TITLE
Color classes homogenization

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\Color;
+
+interface Color
+{
+    public static function fromString(string $string);
+
+    public function red();
+
+    public function green();
+
+    public function blue();
+
+    public function __toString(): string;
+}

--- a/src/Color.php
+++ b/src/Color.php
@@ -12,5 +12,11 @@ interface Color
 
     public function blue();
 
+    public function toHex(): Hex;
+
+    public function toRgb(): Rgb;
+
+    public function toRgba(float $alpha = 1): Rgba;
+
     public function __toString(): string;
 }

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -42,6 +42,11 @@ class Hex implements Color
         return $this->blue;
     }
 
+    public function toHex(): Hex
+    {
+        return new self($this->red, $this->green, $this->blue);
+    }
+
     public function toRgb(): Rgb
     {
         return new Rgb(

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Color;
 
-class Hex
+class Hex implements Color
 {
     /** @var string */
     protected $red, $green, $blue;
@@ -56,7 +56,7 @@ class Hex
         return $this->toRgb()->toRgba($alpha);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return "#{$this->red}{$this->green}{$this->blue}";
     }

--- a/src/Rgb.php
+++ b/src/Rgb.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Color;
 
-class Rgb
+class Rgb implements Color
 {
     /** @var int */
     protected $red, $green, $blue;
@@ -59,7 +59,7 @@ class Rgb
         );
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return "rgb({$this->red},{$this->green},{$this->blue})";
     }

--- a/src/Rgb.php
+++ b/src/Rgb.php
@@ -45,11 +45,6 @@ class Rgb implements Color
         return $this->blue;
     }
 
-    public function toRgba(float $alpha = 1): Rgba
-    {
-        return new Rgba($this->red, $this->green, $this->blue, $alpha);
-    }
-
     public function toHex(): Hex
     {
         return new Hex(
@@ -57,6 +52,16 @@ class Rgb implements Color
             Convert::rgbChannelToHexChannel($this->green),
             Convert::rgbChannelToHexChannel($this->blue)
         );
+    }
+
+    public function toRgb(): Rgb
+    {
+        return new self($this->red, $this->green, $this->blue);
+    }
+
+    public function toRgba(float $alpha = 1): Rgba
+    {
+        return new Rgba($this->red, $this->green, $this->blue, $alpha);
     }
 
     public function __toString(): string

--- a/src/Rgba.php
+++ b/src/Rgba.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\Color;
 
-class Rgba
+class Rgba implements Color
 {
     /** @var int */
     protected $red, $green, $blue;
@@ -65,7 +65,7 @@ class Rgba
         return $this->toRgb()->toHex();
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $alpha = number_format($this->alpha, 2);
 

--- a/src/Rgba.php
+++ b/src/Rgba.php
@@ -55,14 +55,19 @@ class Rgba implements Color
         return $this->alpha;
     }
 
+    public function toHex(): Hex
+    {
+        return $this->toRgb()->toHex();
+    }
+
     public function toRgb(): Rgb
     {
         return new Rgb($this->red, $this->green, $this->blue);
     }
 
-    public function toHex(): Hex
+    public function toRgba(float $alpha = 1): Rgba
     {
-        return $this->toRgb()->toHex();
+        return new self($this->red, $this->green, $this->blue, $alpha);
     }
 
     public function __toString(): string

--- a/tests/HexTest.php
+++ b/tests/HexTest.php
@@ -78,6 +78,18 @@ class HexTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_be_converted_to_hex()
+    {
+        $hex = new Hex('aa', 'bb', 'cc');
+        $newHex = $hex->toHex();
+
+        $this->assertEquals($hex->red(), $newHex->red());
+        $this->assertEquals($hex->green(), $newHex->green());
+        $this->assertEquals($hex->blue(), $newHex->blue());
+        $this->assertNotSame($hex, $newHex);
+    }
+
+    /** @test */
     public function it_can_be_converted_to_rgb()
     {
         $hex = new Hex('aa', 'bb', 'cc');

--- a/tests/RgbTest.php
+++ b/tests/RgbTest.php
@@ -62,6 +62,18 @@ class RgbTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_be_converted_to_rgb()
+    {
+        $rgb = new Rgb(55, 155, 255);
+        $newRgb = $rgb->toRgb();
+
+        $this->assertEquals($rgb->red(), $newRgb->red());
+        $this->assertEquals($rgb->green(), $newRgb->green());
+        $this->assertEquals($rgb->blue(), $newRgb->blue());
+        $this->assertNotSame($rgb, $newRgb);
+    }
+
+    /** @test */
     public function it_can_be_converted_to_rgba_with_a_specific_alpha_value()
     {
         $rgb = new Rgb(55, 155, 255);

--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -80,6 +80,19 @@ class RgbaTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_be_converted_to_rgba_with_with_a_specific_alpha_value()
+    {
+        $rgba = new Rgba(55, 155, 255, 0.5);
+        $newRgba = $rgba->toRgba(0.7);
+
+        $this->assertEquals(55, $newRgba->red());
+        $this->assertEquals(155, $newRgba->green());
+        $this->assertEquals(255, $newRgba->blue());
+        $this->assertEquals(0.7, $newRgba->alpha());
+        $this->assertNotSame($rgba, $newRgba);
+    }
+
+    /** @test */
     public function it_can_be_converted_to_rgb_without_an_alpha_value()
     {
         $rgba = new Rgba(55, 155, 255, 0.5);


### PR DESCRIPTION
**This pull request requires #11 to be approved**

This pull request is really interesting with #12 because it allows to manipulate colors very easily without knowing their types:

```php
// Do we get a Hex, Rgb or Rgba instance? We don't know...
$color = Spatie\Color\Factory::fromString($string);

// Doesn't matter, we can cast it to the type we want, even if its already that type.
$hexColor = $color->toHex();

// This allows us to be sure we will get a string each time we use a channel method.
$hexColor->red();
```