### PR TITLE
Forbid strings with text around the color value

### DIFF
--- a/src/Validate.php
+++ b/src/Validate.php
@@ -33,21 +33,21 @@ class Validate
 
     public static function rgbColorString($string)
     {
-        if (! preg_match('/rgb\( *\d{1,3} *, *\d{1,3} *, *\d{1,3} *\)/i', $string)) {
+        if (! preg_match('/^rgb\( *\d{1,3} *, *\d{1,3} *, *\d{1,3} *\)$/i', $string)) {
             throw InvalidColorValue::malformedRgbColorString($string);
         }
     }
 
     public static function rgbaColorString($string)
     {
-        if (! preg_match('/rgba\( *\d{1,3} *, *\d{1,3} *, *\d{1,3} *, *[0-1](\.\d{1,2})? *\)/i', $string)) {
+        if (! preg_match('/^rgba\( *\d{1,3} *, *\d{1,3} *, *\d{1,3} *, *[0-1](\.\d{1,2})? *\)$/i', $string)) {
             throw InvalidColorValue::malformedRgbaColorString($string);
         }
     }
 
     public static function hexColorString($string)
     {
-        if (! preg_match('/#[a-f0-9]{6}/i', $string)) {
+        if (! preg_match('/^#[a-f0-9]{6}$/i', $string)) {
             throw InvalidColorValue::malformedHexColorString($string);
         }
     }

--- a/tests/HexTest.php
+++ b/tests/HexTest.php
@@ -54,11 +54,19 @@ class HexTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_cant_be_created_from_a_string_with_an_invalid_length()
+    public function it_cant_be_created_from_a_string_with_a_length_too_short()
     {
         $this->expectException(InvalidColorValue::class);
 
         Hex::fromString('#abbcc');
+    }
+
+    /** @test */
+    public function it_cant_be_created_from_a_string_with_a_length_too_long()
+    {
+        $this->expectException(InvalidColorValue::class);
+
+        Hex::fromString('#aabbccddee');
     }
 
     /** @test */

--- a/tests/RgbTest.php
+++ b/tests/RgbTest.php
@@ -65,6 +65,14 @@ class RgbTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_cant_be_created_from_a_string_with_text_around()
+    {
+        $this->expectException(InvalidColorValue::class);
+
+        Rgb::fromString('abc rgb(55,155,255) abc');
+    }
+
+    /** @test */
     public function it_can_be_casted_to_a_string()
     {
         $rgb = new Rgb(55, 155, 255);

--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -84,6 +84,14 @@ class RgbaTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_cant_be_created_from_a_string_with_text_around()
+    {
+        $this->expectException(InvalidColorValue::class);
+
+        Rgba::fromString('abc rgba(55,155,255,0.5) abc');
+    }
+
+    /** @test */
     public function it_can_be_casted_to_a_string()
     {
         $rgba = new Rgba(55, 155, 255, 0.5);


### PR DESCRIPTION
The `#aabbccddee` value was considered valid, so I've fixed the behaviour for all color types.