### PR TITLE
Test enhancement

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,4 @@
 preset: laravel
 
-linting: true
-
 disabled:
   - single_class_element_per_statement

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php" : "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*"
+        "phpunit/phpunit": "^6.5"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -6,9 +6,10 @@ use Spatie\Color\Hex;
 use Spatie\Color\Rgb;
 use Spatie\Color\Rgba;
 use Spatie\Color\Factory;
+use PHPUnit\Framework\TestCase;
 use Spatie\Color\Exceptions\InvalidColorValue;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     /** @test */
     public function it_can_create_a_hex_color_from_a_string()

--- a/tests/HexTest.php
+++ b/tests/HexTest.php
@@ -3,9 +3,10 @@
 namespace Spatie\Color\Test;
 
 use Spatie\Color\Hex;
+use PHPUnit\Framework\TestCase;
 use Spatie\Color\Exceptions\InvalidColorValue;
 
-class HexTest extends \PHPUnit_Framework_TestCase
+class HexTest extends TestCase
 {
     /** @test */
     public function it_is_initializable()

--- a/tests/RgbTest.php
+++ b/tests/RgbTest.php
@@ -3,9 +3,10 @@
 namespace Spatie\Color\Test;
 
 use Spatie\Color\Rgb;
+use PHPUnit\Framework\TestCase;
 use Spatie\Color\Exceptions\InvalidColorValue;
 
-class RgbTest extends \PHPUnit_Framework_TestCase
+class RgbTest extends TestCase
 {
     /** @test */
     public function it_is_initializable()

--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -3,9 +3,10 @@
 namespace Spatie\Color\Test;
 
 use Spatie\Color\Rgba;
+use PHPUnit\Framework\TestCase;
 use Spatie\Color\Exceptions\InvalidColorValue;
 
-class RgbaTest extends \PHPUnit_Framework_TestCase
+class RgbaTest extends TestCase
 {
     /** @test */
     public function it_is_initializable()


### PR DESCRIPTION
# Changed log

- Use the class-based PHPUnit namespace for the stable PHPUnit version.
- Use the latest PHPUnit version to support the multiple stable PHP version.
- Set the ```php-7.2``` test in Travis CI build.