### PR TITLE
Calculate hex color from a string

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -23,7 +23,7 @@ class Factory
 
     public static function stringToColor(string $string): Color
     {
-        return static::fromString('#'. substr(dechex(crc32($string)), 0, 6));
+        return static::fromString('#'.substr(dechex(crc32($string)), 0, 6));
     }
 
     protected static function getColorClasses(): array

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -21,6 +21,11 @@ class Factory
         throw InvalidColorValue::malformedColorString($string);
     }
 
+    public static function stringToColor(string $string): Color
+    {
+        return static::fromString('#'. substr(dechex(crc32($string)), 0, 6));
+    }
+
     protected static function getColorClasses(): array
     {
         return [

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -24,7 +24,7 @@ class FactoryTest extends TestCase
     /** @test */
     public function it_can_create_a_hex_color_calculating_a_string_hash()
     {
-        $hex = Factory::stringToColor("Hello world!");
+        $hex = Factory::stringToColor('Hello world!');
 
         $this->assertInstanceOf(Hex::class, $hex);
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -22,6 +22,14 @@ class FactoryTest extends TestCase
     }
 
     /** @test */
+    public function it_can_create_a_hex_color_calculating_a_string_hash()
+    {
+        $hex = Factory::stringToColor("Hello world!");
+
+        $this->assertInstanceOf(Hex::class, $hex);
+    }
+
+    /** @test */
     public function it_can_create_a_hsl_color_from_a_string()
     {
         $hsl = Factory::fromString('hsl(127, 45%, 71%)');


### PR DESCRIPTION
Added a method to generate a color from a string.

```php
echo \Spatie\Color\Factory::stringToColor('Hello world')->__toString(); // #8bd69e
echo \Spatie\Color\Factory::stringToColor('HEllo world')->__toString(); // #c48b9d
echo \Spatie\Color\Factory::stringToColor('Spatie')->__toString(); // #9b8f2e
echo \Spatie\Color\Factory::stringToColor('masterix21')->__toString(); // #cd3ae8
```