### PR TITLE
Fix 'PHP Deprecated: Implicit conversion from float to int loses precision' errors in PHP 8

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -57,7 +57,7 @@ class Convert
 
     public static function hslValueToRgb(float $hue, float $saturation, float $lightness): array
     {
-        $h = (360 + ($hue % 360)) % 360;  // hue values can be less than 0 and greater than 360. This normalises them into the range 0-360.
+        $h = intval((360 + (intval($hue) % 360)) % 360);  // hue values can be less than 0 and greater than 360. This normalises them into the range 0-360.
 
         $c = (1 - abs(2 * ($lightness / 100) - 1)) * ($saturation / 100);
         $x = $c * (1 - abs(fmod($h / 60, 2) - 1));
@@ -234,9 +234,9 @@ class Convert
             $b = 12.92 * $b;
         }
 
-        $r = max(0, min(255, $r * 255));
-        $g = max(0, min(255, $g * 255));
-        $b = max(0, min(255, $b * 255));
+        $r = intval(max(0, min(255, $r * 255)));
+        $g = intval(max(0, min(255, $g * 255)));
+        $b = intval(max(0, min(255, $b * 255)));
 
         return [$r, $g, $b];
     }

--- a/src/Exceptions/InvalidColorValue.php
+++ b/src/Exceptions/InvalidColorValue.php
@@ -16,7 +16,7 @@ class InvalidColorValue extends Exception
         return new static("An rgb values must be an integer between 0 and 255, `{$value}` provided for channel {$channel}.");
     }
 
-    public static function alphaChannelValueNotInRange(int $value): self
+    public static function alphaChannelValueNotInRange(float $value): self
     {
         return new static("An alpha values must be a float between 0 and 1, `{$value}` provided.");
     }


### PR DESCRIPTION
Running the tests in PHP 8 throws a bunch of errors about losing precision when converting from float to int. This PR simply makes sure the correct variable types are being passed/converted thus making the tests pass again in PHP 8.