### PR TITLE
Add a test for opacity without leading zero

### DIFF
--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -73,7 +73,7 @@ class RgbaTest extends TestCase
         $this->assertSame(55, $rgba->red());
         $this->assertSame(155, $rgba->green());
         $this->assertSame(255, $rgba->blue());
-        $this->assertSame(.555, $rgba->alpha());
+        $this->assertSame(0.555, $rgba->alpha());
     }
 
 

--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -65,6 +65,19 @@ class RgbaTest extends TestCase
     }
 
     /** @test */
+    public function it_can_be_created_with_an_opacity_value_without_leading_zero()
+    {
+        $rgba = Rgba::fromString('rgba(55,155,255,.555)');
+
+        $this->assertInstanceOf(Rgba::class, $rgba);
+        $this->assertSame(55, $rgba->red());
+        $this->assertSame(155, $rgba->green());
+        $this->assertSame(255, $rgba->blue());
+        $this->assertSame(.555, $rgba->alpha());
+    }
+
+
+    /** @test */
     public function it_can_be_created_from_a_string_with_3_decimals_in_opacity()
     {
         $rgba = Rgba::fromString('rgba(55,155,255,0.555)');


### PR DESCRIPTION
Not super-good at writing tests, so while I think the syntax of added test is correct, probably good someone checks... thanks!