### PR TITLE
Fix typo in Distance::CIE76.

### DIFF
--- a/src/Distance.php
+++ b/src/Distance.php
@@ -23,7 +23,7 @@ class Distance
 
         $sum = 0;
         $sum += pow($lab1->l() - $lab2->l(), 2);
-        $sum += pow($lab1->a() - $lab2->b(), 2);
+        $sum += pow($lab1->a() - $lab2->a(), 2);
         $sum += pow($lab1->b() - $lab2->b(), 2);
 
         return max(min(sqrt($sum), 100), 0);

--- a/tests/DistanceTest.php
+++ b/tests/DistanceTest.php
@@ -16,7 +16,7 @@ class DistanceTest extends TestCase
         $color2 = Hex::fromString('#2d78c8');
         $distance = Distance::CIE76($color1, $color2);
 
-        $this->assertSame(55.89468042667388, $distance);
+        $this->assertSame(16.35058714542080, $distance);
     }
 
     /** @test */
@@ -24,7 +24,7 @@ class DistanceTest extends TestCase
     {
         $distance = Distance::CIE76('rgb(55,155,255)', '#2d78c8');
 
-        $this->assertSame(55.89468042667388, $distance);
+        $this->assertSame(16.35058714542080, $distance);
     }
 
     /** @test */


### PR DESCRIPTION
Correct CIE76 distance between rgb(55,155,255) and #2d78c8 is something about 16.35.