### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.1, 8.0, 7.4, 7.3]
+                php: [8.2, 8.1, 8.0, 7.4, 7.3]
                 stability: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1.0_