### PR TITLE
Fix rgb to cmyk division by zero bug

### DIFF
--- a/src/Convert.php
+++ b/src/Convert.php
@@ -64,9 +64,9 @@ class Convert
         $keyNeg = (1 - $black);
 
         return [
-            ($keyNeg - $red) / $keyNeg,
-            ($keyNeg - $green) / $keyNeg,
-            ($keyNeg - $blue) / $keyNeg,
+            (1 - $red - $black) / ($keyNeg ?: 1),
+            (1 - $green - $black) / ($keyNeg ?: 1),
+            (1 - $blue - $black) / ($keyNeg ?: 1),
             $black,
         ];
     }

--- a/tests/HexTest.php
+++ b/tests/HexTest.php
@@ -108,6 +108,15 @@ it('can be converted to cmyk', function () {
     assertSame(204, $cmyk->blue());
 });
 
+it('can be converted from hex("00", "00", "00") to cmyk', function () {
+    $hex = new Hex('00', '00', '00');
+    $cmyk = $hex->toCmyk();
+
+    assertSame(0, $cmyk->red());
+    assertSame(0, $cmyk->green());
+    assertSame(0, $cmyk->blue());
+});
+
 it('can be converted to hex', function () {
     $hex = new Hex('aa', 'bb', 'cc');
     $newHex = $hex->toHex();

--- a/tests/RgbTest.php
+++ b/tests/RgbTest.php
@@ -84,6 +84,15 @@ it('can be converted to rgb', function () {
     assertNotSame($rgb, $newRgb);
 });
 
+it('can be converted from rgb(0,0,0) to cmyk', function () {
+    $rgb = new Rgb(0, 0, 0);
+    $cmyk = $rgb->toCmyk();
+
+    assertSame($rgb->red(), $cmyk->red());
+    assertSame($rgb->green(), $cmyk->green());
+    assertSame($rgb->blue(), $cmyk->blue());
+});
+
 it('can be converted to rgba with a specific alpha value', function () {
     $rgb = new Rgb(55, 155, 255);
     $rgba = $rgb->toRgba(0.5);


### PR DESCRIPTION
There was a bug when converting rgb(0,0,0) to Cmyk

`$rgb = (new Rgb(0,0,0))->toCmyk();`
`PHP Error:  Division by zero in .../vendor/spatie/color/src/Convert.php on line 67`

This error occurs when `$keyNeg` will be 0.

Another bug is when converting i.e. rgb(27,12,98) to Cmyk.

`$rgb = (new Rgb(27,12,98))->toCmyk();`
`Spatie\Color\Exceptions\InvalidColorValue with message 'Cmyk value `yellow` must be a number between 0 and 1'`

I fixed both bugs and added tests.
