### PR TITLE
Enable alpha color conversion between Hex, Hsla, and Rgba formats

### DIFF
--- a/src/CIELab.php
+++ b/src/CIELab.php
@@ -79,9 +79,9 @@ class CIELab implements Color
         return $this->toRgb()->toCmyk();
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return $this->toRgb()->toHex($alpha);
+        return $this->toRgb()->toHex($alpha ?? 'ff');
     }
 
     public function toHsb(): Hsb
@@ -94,9 +94,9 @@ class CIELab implements Color
         return $this->toRgb()->toHSL();
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        return $this->toRgb()->toHsla($alpha);
+        return $this->toRgb()->toHsla($alpha ?? 1);
     }
 
     public function toRgb(): Rgb
@@ -104,9 +104,9 @@ class CIELab implements Color
         return $this->toXyz()->toRgb();
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return $this->toRgb()->toRgba($alpha);
+        return $this->toRgb()->toRgba($alpha ?? 1);
     }
 
     public function toXyz(): Xyz

--- a/src/Cmyk.php
+++ b/src/Cmyk.php
@@ -83,9 +83,9 @@ class Cmyk implements Color
         return $this->toRgb()->toCIELab();
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return $this->toRgb()->toHex($alpha);
+        return $this->toRgb()->toHex($alpha ?? 'ff');
     }
 
     public function toHsb(): Hsb
@@ -98,9 +98,9 @@ class Cmyk implements Color
         return $this->toRgb()->toHsl();
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        return $this->toRgb()->toHsla($alpha);
+        return $this->toRgb()->toHsla($alpha ?? 1);
     }
 
     public function toRgb(): Rgb
@@ -110,9 +110,9 @@ class Cmyk implements Color
         return new Rgb($red, $green, $blue);
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return $this->toRgb()->toRgba($alpha);
+        return $this->toRgb()->toRgba($alpha ?? 1);
     }
 
     public function toXyz(): Xyz

--- a/src/Color.php
+++ b/src/Color.php
@@ -14,17 +14,17 @@ interface Color
 
     public function toCIELab(): CIELab;
 
-    public function toHex(string $alpha = 'ff'): Hex;
+    public function toHex(?string $alpha = null): Hex;
 
     public function toHsb(): Hsb;
 
     public function toHsl(): Hsl;
 
-    public function toHsla(float $alpha = 1): Hsla;
+    public function toHsla(?float $alpha = null): Hsla;
 
     public function toRgb(): Rgb;
 
-    public function toRgba(float $alpha = 1): Rgba;
+    public function toRgba(?float $alpha = null): Rgba;
 
     public function toXyz(): Xyz;
 

--- a/src/Convert.php
+++ b/src/Convert.php
@@ -81,6 +81,16 @@ class Convert
         return str_pad(dechex($rgbValue), 2, '0', STR_PAD_LEFT);
     }
 
+    public static function hexAlphaToFloat(string $hexAlpha): float
+    {
+        return round(static::hexChannelToRgbChannel($hexAlpha) / 255, 2);
+    }
+
+    public static function floatAlphaToHex(float $floatAlpha): string
+    {
+        return static::rgbChannelToHexChannel(round($floatAlpha * 255, 0));
+    }
+
     public static function hsbValueToRgb($hue, $saturation, $brightness)
     {
         while ($hue > 360) {

--- a/src/Hex.php
+++ b/src/Hex.php
@@ -94,9 +94,9 @@ class Hex implements Color
         return $this->toRgb()->toCmyk();
     }
 
-    public function toHex(string $alpha = 'ff'): self
+    public function toHex(?string $alpha = null): self
     {
-        return new self($this->red, $this->green, $this->blue, $alpha);
+        return new self($this->red, $this->green, $this->blue, $alpha ?? $this->alpha);
     }
 
     public function toHsb(): Hsb
@@ -115,15 +115,9 @@ class Hex implements Color
         return new Hsl($hue, $saturation, $lightness);
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        [$hue, $saturation, $lightness] = Convert::rgbValueToHsl(
-            Convert::hexChannelToRgbChannel($this->red),
-            Convert::hexChannelToRgbChannel($this->green),
-            Convert::hexChannelToRgbChannel($this->blue)
-        );
-
-        return new Hsla($hue, $saturation, $lightness, $alpha);
+        return $this->toRgb()->toHsla($alpha ?? Convert::hexAlphaToFloat($this->alpha));
     }
 
     public function toRgb(): Rgb
@@ -135,9 +129,9 @@ class Hex implements Color
         );
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return $this->toRgb()->toRgba($alpha);
+        return $this->toRgb()->toRgba($alpha ?? Convert::hexAlphaToFloat($this->alpha));
     }
 
     public function toXyz(): Xyz

--- a/src/Hsb.php
+++ b/src/Hsb.php
@@ -79,14 +79,9 @@ class Hsb implements Color
         return new self($this->hue, $this->saturation, $this->brightness);
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return new Hex(
-            Convert::rgbChannelToHexChannel($this->red()),
-            Convert::rgbChannelToHexChannel($this->green()),
-            Convert::rgbChannelToHexChannel($this->blue()),
-            $alpha
-        );
+        return $this->toRgb()->toHex($alpha ?? 'ff');
     }
 
     public function toHsl(): Hsl
@@ -94,9 +89,9 @@ class Hsb implements Color
         return $this->toRgb()->toHsl();
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        return $this->toRgb()->toHsla($alpha);
+        return $this->toRgb()->toHsla($alpha ?? 1);
     }
 
     public function toRgb(): Rgb
@@ -104,9 +99,9 @@ class Hsb implements Color
         return new Rgb($this->red(), $this->green(), $this->blue());
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return new Rgba($this->red(), $this->green(), $this->blue(), $alpha);
+        return new Rgba($this->red(), $this->green(), $this->blue(), $alpha ?? 1);
     }
 
     public function toXyz(): Xyz

--- a/src/Hsl.php
+++ b/src/Hsl.php
@@ -75,14 +75,9 @@ class Hsl implements Color
         return $this->toRgb()->toCmyk();
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return new Hex(
-            Convert::rgbChannelToHexChannel($this->red()),
-            Convert::rgbChannelToHexChannel($this->green()),
-            Convert::rgbChannelToHexChannel($this->blue()),
-            $alpha
-        );
+        return $this->toRgb()->toHex($alpha ?? 'ff');
     }
 
     public function toHsb(): Hsb
@@ -95,9 +90,9 @@ class Hsl implements Color
         return new self($this->hue(), $this->saturation(), $this->lightness());
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        return new Hsla($this->hue(), $this->saturation(), $this->lightness(), $alpha);
+        return new Hsla($this->hue(), $this->saturation(), $this->lightness(), $alpha ?? 1);
     }
 
     public function toRgb(): Rgb
@@ -105,9 +100,9 @@ class Hsl implements Color
         return new Rgb($this->red(), $this->green(), $this->blue());
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return new Rgba($this->red(), $this->green(), $this->blue(), $alpha);
+        return new Rgba($this->red(), $this->green(), $this->blue(), $alpha ?? 1);
     }
 
     public function toXyz(): Xyz

--- a/src/Hsla.php
+++ b/src/Hsla.php
@@ -87,14 +87,9 @@ class Hsla implements Color
         return $this->toRgb()->toCmyk();
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return new Hex(
-            Convert::rgbChannelToHexChannel($this->red()),
-            Convert::rgbChannelToHexChannel($this->green()),
-            Convert::rgbChannelToHexChannel($this->blue()),
-            $alpha
-        );
+        return $this->toRgb()->toHex($alpha ?? Convert::floatAlphaToHex($this->alpha));
     }
 
     public function toHsb(): Hsb
@@ -102,9 +97,9 @@ class Hsla implements Color
         return $this->toRgb()->toHsb();
     }
 
-    public function toHsla(float $alpha = 1): self
+    public function toHsla(?float $alpha = null): self
     {
-        return new self($this->hue(), $this->saturation(), $this->lightness(), $alpha);
+        return new self($this->hue(), $this->saturation(), $this->lightness(), $alpha ?? $this->alpha);
     }
 
     public function toHsl(): Hsl
@@ -117,9 +112,9 @@ class Hsla implements Color
         return new Rgb($this->red(), $this->green(), $this->blue());
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return new Rgba($this->red(), $this->green(), $this->blue(), $alpha);
+        return new Rgba($this->red(), $this->green(), $this->blue(), $alpha ?? $this->alpha);
     }
 
     public function toXyz(): Xyz

--- a/src/Rgb.php
+++ b/src/Rgb.php
@@ -60,13 +60,13 @@ class Rgb implements Color
         return new Cmyk($cyan, $magenta, $yellow, $key);
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
         return new Hex(
             Convert::rgbChannelToHexChannel($this->red),
             Convert::rgbChannelToHexChannel($this->green),
             Convert::rgbChannelToHexChannel($this->blue),
-            $alpha
+            $alpha ?? 'ff'
         );
     }
 
@@ -88,7 +88,7 @@ class Rgb implements Color
         return new Hsl($hue, $saturation, $lightness);
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
         [$hue, $saturation, $lightness] = Convert::rgbValueToHsl(
             $this->red,
@@ -96,7 +96,7 @@ class Rgb implements Color
             $this->blue
         );
 
-        return new Hsla($hue, $saturation, $lightness, $alpha);
+        return new Hsla($hue, $saturation, $lightness, $alpha ?? 1);
     }
 
     public function toRgb(): self
@@ -104,9 +104,9 @@ class Rgb implements Color
         return new self($this->red, $this->green, $this->blue);
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return new Rgba($this->red, $this->green, $this->blue, $alpha);
+        return new Rgba($this->red, $this->green, $this->blue, $alpha ?? 1);
     }
 
     public function toXyz(): Xyz

--- a/src/Rgba.php
+++ b/src/Rgba.php
@@ -68,9 +68,9 @@ class Rgba implements Color
         return $this->toRgb()->toCmyk();
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return $this->toRgb()->toHex($alpha);
+        return $this->toRgb()->toHex($alpha ?? Convert::floatAlphaToHex($this->alpha));
     }
 
     public function toHsb(): Hsb
@@ -89,15 +89,9 @@ class Rgba implements Color
         return new Hsl($hue, $saturation, $lightness);
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        [$hue, $saturation, $lightness] = Convert::rgbValueToHsl(
-            $this->red,
-            $this->green,
-            $this->blue
-        );
-
-        return new Hsla($hue, $saturation, $lightness, $alpha);
+        return $this->toRgb()->toHsla($alpha ?? $this->alpha);
     }
 
     public function toRgb(): Rgb
@@ -105,9 +99,9 @@ class Rgba implements Color
         return new Rgb($this->red, $this->green, $this->blue);
     }
 
-    public function toRgba(float $alpha = 1): self
+    public function toRgba(?float $alpha = null): self
     {
-        return new self($this->red, $this->green, $this->blue, $alpha);
+        return new self($this->red, $this->green, $this->blue, $alpha ?? $this->alpha);
     }
 
     public function toXyz(): Xyz

--- a/src/Xyz.php
+++ b/src/Xyz.php
@@ -85,9 +85,9 @@ class Xyz implements Color
         return $this->toRgb()->toCmyk();
     }
 
-    public function toHex(string $alpha = 'ff'): Hex
+    public function toHex(?string $alpha = null): Hex
     {
-        return $this->toRgb()->toHex($alpha);
+        return $this->toRgb()->toHex($alpha ?? 'ff');
     }
 
     public function toHsb(): Hsb
@@ -100,9 +100,9 @@ class Xyz implements Color
         return $this->toRgb()->toHSL();
     }
 
-    public function toHsla(float $alpha = 1): Hsla
+    public function toHsla(?float $alpha = null): Hsla
     {
-        return $this->toRgb()->toHsla($alpha);
+        return $this->toRgb()->toHsla($alpha ?? 1);
     }
 
     public function toRgb(): Rgb
@@ -116,9 +116,9 @@ class Xyz implements Color
         return new Rgb($red, $green, $blue);
     }
 
-    public function toRgba(float $alpha = 1): Rgba
+    public function toRgba(?float $alpha = null): Rgba
     {
-        return $this->toRgb()->toRgba($alpha);
+        return $this->toRgb()->toRgba($alpha ?? 1);
     }
 
     public function toXyz(): self

--- a/tests/HexTest.php
+++ b/tests/HexTest.php
@@ -118,13 +118,20 @@ it('can be converted from hex("00", "00", "00") to cmyk', function () {
 });
 
 it('can be converted to hex', function () {
-    $hex = new Hex('aa', 'bb', 'cc');
+    $hex = new Hex('aa', 'bb', 'cc', 'dd');
     $newHex = $hex->toHex();
+
+    assertSame(serialize($hex), serialize($newHex));
+});
+
+it('can be converted to hex with a specific alpha value', function () {
+    $hex = new Hex('aa', 'bb', 'cc');
+    $newHex = $hex->toHex('dd');
 
     assertSame($hex->red(), $newHex->red());
     assertSame($hex->green(), $newHex->green());
     assertSame($hex->blue(), $newHex->blue());
-    assertNotSame($hex, $newHex);
+    assertNotSame(serialize($hex), serialize($newHex));
 });
 
 it('can be converted to hsl', function () {
@@ -163,6 +170,16 @@ it('can be converted to hsl with a black value', function () {
     assertSame(0, $hsl->blue());
 });
 
+it('can be converted to hsla', function () {
+    $hex = new Hex('aa', 'bb', 'cc', 'dd');
+    $hsla = $hex->toHsla();
+
+    assertSame(170, $hsla->red());
+    assertSame(187, $hsla->green());
+    assertSame(204, $hsla->blue());
+    assertSame(0.87, $hsla->alpha());
+});
+
 it('can be converted to hsla with a specific alpha value', function () {
     $hex = new Hex('aa', 'bb', 'cc');
     $hsla = $hex->toHsla(0.75);
@@ -183,6 +200,16 @@ it('can be converted to rgb', function () {
 });
 
 it('can be converted to rgba', function () {
+    $hex = new Hex('aa', 'bb', 'cc', 'dd');
+    $rgba = $hex->toRgba();
+
+    assertSame(170, $rgba->red());
+    assertSame(187, $rgba->green());
+    assertSame(204, $rgba->blue());
+    assertSame(0.87, $rgba->alpha());
+});
+
+it('can be converted to rgba with a specific alpha value', function () {
     $hex = new Hex('aa', 'bb', 'cc');
     $rgba = $hex->toRgba(0.5);
 

--- a/tests/HslaTest.php
+++ b/tests/HslaTest.php
@@ -112,6 +112,13 @@ it('can be converted to cmyk', function () {
 });
 
 it('can be converted to hsla', function () {
+    $hsla = new Hsla(55, 55, 67, 0.5);
+    $newHsla = $hsla->toHsla();
+
+    assertSame(serialize($hsla), serialize($newHsla));
+});
+
+it('can be converted to hsla with a specific alpha value', function () {
     $hsla = new Hsla(55, 55, 67);
     $newHsla = $hsla->toHsla(0.5);
 
@@ -119,7 +126,7 @@ it('can be converted to hsla', function () {
     assertSame($hsla->saturation(), $newHsla->saturation());
     assertSame($hsla->lightness(), $newHsla->lightness());
     assertSame(0.5, $newHsla->alpha());
-    assertNotSame($hsla, $newHsla);
+    assertNotSame(serialize($hsla), serialize($newHsla));
 });
 
 it('can be converted to hsl', function () {
@@ -140,6 +147,16 @@ it('can be converted to rgb', function () {
     assertSame(125, $rgb->blue());
 });
 
+it('can be converted to rgba', function () {
+    $hsla = new Hsla(55, 55, 67, 0.6);
+    $rgba = $hsla->toRgba();
+
+    assertSame(217, $rgba->red());
+    assertSame(209, $rgba->green());
+    assertSame(125, $rgba->blue());
+    assertSame(0.6, $rgba->alpha());
+});
+
 it('can be converted to rgba with a specific alpha value', function () {
     $hsla = new Hsla(55, 55, 67);
     $rgba = $hsla->toRgba(0.5);
@@ -151,12 +168,23 @@ it('can be converted to rgba with a specific alpha value', function () {
 });
 
 it('can be converted to hex', function () {
-    $hsla = new Hsla(55, 55, 67);
+    $hsla = new Hsla(55, 55, 67, 0.5);
     $hex = $hsla->toHex();
 
     assertSame('d9', $hex->red());
     assertSame('d1', $hex->green());
     assertSame('7d', $hex->blue());
+    assertSame('80', $hex->alpha());
+});
+
+it('can be converted to hex with a specific alpha value', function () {
+    $hsla = new Hsla(55, 55, 67, 0.5);
+    $hex = $hsla->toHex('dd');
+
+    assertSame('d9', $hex->red());
+    assertSame('d1', $hex->green());
+    assertSame('7d', $hex->blue());
+    assertSame('dd', $hex->alpha());
 });
 
 it('can be converted to xyz', function () {

--- a/tests/RgbaTest.php
+++ b/tests/RgbaTest.php
@@ -105,6 +105,13 @@ it('can be converted to cmyk', function () {
     assertSame($rgba->blue(), $cmyk->blue());
 });
 
+it('can be converted to rgba', function () {
+    $rgba = new Rgba(55, 155, 255, 0.5);
+    $newRgba = $rgba->toRgba();
+
+    assertSame(serialize($rgba), serialize($newRgba));
+});
+
 it('can be converted to rgba with with a specific alpha value', function () {
     $rgba = new Rgba(55, 155, 255, 0.5);
     $newRgba = $rgba->toRgba(0.7);
@@ -113,7 +120,7 @@ it('can be converted to rgba with with a specific alpha value', function () {
     assertSame(155, $newRgba->green());
     assertSame(255, $newRgba->blue());
     assertSame(0.7, $newRgba->alpha());
-    assertNotSame($rgba, $newRgba);
+    assertNotSame(serialize($rgba), serialize($newRgba));
 });
 
 it('can be converted to rgb without an alpha value', function () {
@@ -125,13 +132,24 @@ it('can be converted to rgb without an alpha value', function () {
     assertSame(255, $rgb->blue());
 });
 
-it('can be converted to hex without an alpha value', function () {
+it('can be converted to hex', function () {
     $rgba = new Rgba(55, 155, 255, 0.5);
     $hex = $rgba->toHex();
 
     assertSame('37', $hex->red());
     assertSame('9b', $hex->green());
     assertSame('ff', $hex->blue());
+    assertSame('80', $hex->alpha());
+});
+
+it('can be converted to hex with a specific alpha value', function () {
+    $rgba = new Rgba(55, 155, 255, 0.5);
+    $hex = $rgba->toHex('dd');
+
+    assertSame('37', $hex->red());
+    assertSame('9b', $hex->green());
+    assertSame('ff', $hex->blue());
+    assertSame('dd', $hex->alpha());
 });
 
 it('can be converted to hsl without an alpha value', function () {
@@ -141,6 +159,16 @@ it('can be converted to hsl without an alpha value', function () {
     assertSame(55, $hsl->red());
     assertSame(155, $hsl->green());
     assertSame(255, $hsl->blue());
+});
+
+it('can be converted to hsla', function () {
+    $rgba = new Rgba(55, 155, 255, 0.5);
+    $hsla = $rgba->toHsla();
+
+    assertSame(55, $hsla->red());
+    assertSame(155, $hsla->green());
+    assertSame(255, $hsla->blue());
+    assertSame(0.5, $hsla->alpha());
 });
 
 it('can be converted to hsla with a specific alpha value', function () {


### PR DESCRIPTION
## Description

This PR enables alpha color conversion between Hex, Hsla, and Rgba formats.
```php
$rgba = new Rgba(55, 155, 255, 0.5);

$hex = $rgba->toHex();
$hexString = (string) $hex; // '#379bff80'
$hexAlpha = $hex->alpha(); // '80'

$newRgba = $hex->toRgba();
$newRgbaString = (string) $newRgba; // rgba(55,155,255,0.5)
$newRgbaAlpha = $newRgba->alpha(); // 0.5
```
For non-alpha color systems, the default alpha value will be used as 1 (or 'ff'). You can still pass a custom alpha value.